### PR TITLE
Small improvements 

### DIFF
--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -674,7 +674,7 @@ void ffguiwin::MessageReceived(BMessage *message)
 		}
 		case M_ENCODE:
 		{
-			printf("M_ENCODE: Encode button pressed\n");
+			commandline->SetTo(encode->Text());
 			char run[4096];
 			sprintf(run,"Terminal %s",commandline->String());
 			printf("Running command: %s\n", commandline->String());

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -105,6 +105,8 @@ void ffguiwin::BuildLine() // ask all the views what they hold, reset the comman
 ffguiwin::ffguiwin(BRect r, char *name, window_type type, ulong mode)
 	: BWindow(r,name,type,mode)
 {
+	sourcefile_specified = false;
+	outputfile_specified = false;
 
 	//initialize GUI elements
 	sourcefilebutton = new BButton("Source file", new BMessage(M_SOURCE));
@@ -178,6 +180,7 @@ ffguiwin::ffguiwin(BRect r, char *name, window_type type, ulong mode)
 	abouttext = new BTextView("");
 	abouttext->SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
 	encodebutton = new BButton("Encode", new BMessage(M_ENCODE));
+	encodebutton->SetEnabled(false);
 	encode = new BTextControl("", "", nullptr);
 	
 	fSourceFilePanel = new BFilePanel(B_OPEN_PANEL,
@@ -437,12 +440,25 @@ void ffguiwin::MessageReceived(BMessage *message)
 	switch(message->what)
 	{
 		case M_NOMSG:
-		case M_SOURCEFILE:
-		case M_OUTPUTFILE:
 		{
 			BuildLine();
 			break;
-		}			
+		}
+		case M_SOURCEFILE:
+		{
+			BuildLine();
+			sourcefile_specified = !(BString(sourcefile->Text()).Trim().IsEmpty());
+			set_encodebutton_state();
+			break;	
+		}
+		case M_OUTPUTFILE:	
+		{
+			BuildLine();
+			outputfile_specified = !(BString(outputfile->Text()).Trim().IsEmpty());
+			set_encodebutton_state();
+			break;	
+		}	
+		
 /*		case '_PBL':
 		{
 			BuildLine();
@@ -652,9 +668,10 @@ void ffguiwin::MessageReceived(BMessage *message)
 			message->FindRef("refs", &ref);
 			BEntry file_entry(&ref, true);
 			BPath file_path(&file_entry);
-
 			sourcefile->SetText(file_path.Path());
 			BuildLine();
+			sourcefile_specified = true;
+			set_encodebutton_state();
 			break;
 		}
 		case M_OUTPUTFILE_REF:
@@ -670,6 +687,8 @@ void ffguiwin::MessageReceived(BMessage *message)
 			
 			outputfile->SetText(filename);
 			BuildLine();
+			outputfile_specified = true;
+			set_encodebutton_state();
 			break;
 		}
 		case M_ENCODE:
@@ -692,3 +711,21 @@ void ffguiwin::MessageReceived(BMessage *message)
 			break;
 	}
 }
+
+
+void ffguiwin::set_encodebutton_state()
+{
+	bool encodebutton_enabled;
+
+	if (sourcefile_specified && outputfile_specified)
+	{
+		encodebutton_enabled = true;
+	}
+	else
+	{
+		encodebutton_enabled = false;
+	}
+	
+	encodebutton->SetEnabled(encodebutton_enabled);
+}
+

--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -36,6 +36,7 @@ class ffguiwin : public BWindow
 
 
 	private:
+			void set_encodebutton_state();
 			//main view
 			BView *topview; 
 			// text views
@@ -92,6 +93,7 @@ class ffguiwin : public BWindow
 			//MProgressBar *encodestatus;
 			// bools
 			bool benablevideo, benableaudio, benablecropping, bdeletesource,bcustomres;
+			bool sourcefile_specified, outputfile_specified;
 			// bstrings
 			BString *commandline;
 			// file panels


### PR DESCRIPTION
- Use the actual commandline in the textcontrol when pressing the encode button. That way the commandline can be edited by hand before executing. Fixes #11 
- Start with encode button disabled. Only enable the button when both source and output file is specified. 