### PR TITLE
Quote file names in ffmpeg commandline

### DIFF
--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -29,7 +29,7 @@
 void ffguiwin::BuildLine() // ask all the views what they hold, reset the command string
 {
 	BString commandline("ffmpeg -i ");
-	commandline << sourcefile->Text();  //append the input file name
+	commandline << "\"" << sourcefile->Text() << "\"";  //append the input file name
 	commandline << " -f " << outputfileformat->MenuItem()->Label(); // grab and set the file format
 
 	if (benablevideo == false) // is video enabled, add options
@@ -81,8 +81,7 @@ void ffguiwin::BuildLine() // ask all the views what they hold, reset the comman
 	{
 		commandline << (" -an");
 	}
-	commandline << (" ");
-	commandline << (outputfile->Text());
+	commandline << " \"" << outputfile->Text() << "\"";
 	encode->SetText(commandline.String());
 }
 

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -29,25 +29,25 @@
 void ffguiwin::BuildLine() // ask all the views what they hold, reset the command string
 {
 	char buff[64];
-	commandline = new BString("ffmpeg -i ");
+	BString commandline("ffmpeg -i ");
 	const char *contents (sourcefile->Text()); //append the input file name
-	commandline->Append(contents);
+	commandline.Append(contents);
 
 	sprintf(buff," -f %s",outputfileformat->MenuItem()->Label()); // grab and set the file format
-	commandline->Append(buff);
+	commandline.Append(buff);
 
 	if (benablevideo == false) // is video enabled, add options
 	{
 		sprintf(buff," -vcodec %s",outputvideoformat->MenuItem()->Label()); // grab and set the video encoder
-		commandline->Append(buff);
+		commandline.Append(buff);
 		sprintf(buff," -b:v %d",(int)vbitrate->Value());
-		commandline->Append(buff);
+		commandline.Append(buff);
 		sprintf(buff," -r %d",(int)framerate->Value());
-		commandline->Append(buff);
+		commandline.Append(buff);
 		if (bcustomres == true)
 		{
 			sprintf(buff," -s %dx%d",(int)xres->Value(),(int)yres->Value());
-			commandline->Append(buff);
+			commandline.Append(buff);
 		}
 
 		// cropping options -- no point in cropping if we aren't encoding video...
@@ -58,50 +58,50 @@ void ffguiwin::BuildLine() // ask all the views what they hold, reset the comman
 			if ((int)topcrop->Value() != 0)
 			{
 				sprintf(buff," -vf crop=w=in_w:h=in_h:x=0:y=%d",(int)topcrop->Value());
-				commandline->Append(buff);
+				commandline.Append(buff);
 			}
 			if ((int)bottomcrop->Value() != 0)
 			{
 				sprintf(buff," -vf crop=w=in_w:h=in_h-%d:x=0:y=0",(int)bottomcrop->Value());
-				commandline->Append(buff);
+				commandline.Append(buff);
 			}
 			if ((int)leftcrop->Value() != 0)
 			{
 				sprintf(buff," -vf crop=w=in_w:h=in_h:x=%d:y=0",(int)leftcrop->Value());
-				commandline->Append(buff);
+				commandline.Append(buff);
 			}
 			if ((int)rightcrop->Value() != 0)
 			{
 				sprintf(buff," -vf crop=w=in_w-%d:h=in_h:x=0:y=0",(int)rightcrop->Value());
-				commandline->Append(buff);
+				commandline.Append(buff);
 			}
 		}
 	}
 	else //nope, add the no video encoding flag
 	{
-		commandline->Append(" -vn");
+		commandline.Append(" -vn");
 	}
 
 	if (benableaudio == true) // audio encoding enabled, grab the values
 	{
 		sprintf(buff," -acodec %s",outputaudioformat->MenuItem()->Label());
-		commandline->Append(buff);
+		commandline.Append(buff);
 		sprintf(buff," -b:a %d",(int)ab->Value());
-		commandline->Append(buff);
+		commandline.Append(buff);
 		sprintf(buff," -ar %d",(int)ar->Value());
-		commandline->Append(buff);
+		commandline.Append(buff);
 		sprintf(buff," -ac %d",(int)ac->Value());
-		commandline->Append(buff);
+		commandline.Append(buff);
 	}
 	else
 	{
-		commandline->Append(" -an");
+		commandline.Append(" -an");
 	}
-	commandline->Append(" ");
-	commandline->Append(outputfile->Text());
-	printf(commandline->String());
+	commandline.Append(" ");
+	commandline.Append(outputfile->Text());
+	printf(commandline.String());
 	printf("\n");
-	encode->SetText(commandline->String());
+	encode->SetText(commandline.String());
 }
 
 // new window object
@@ -706,8 +706,8 @@ void ffguiwin::MessageReceived(BMessage *message)
 			outputtext->SelectAll();
 			outputtext->Clear();
 			//tabview->Select(2);
-			commandline->SetTo(encode->Text());
-			commandline->Append(" -y");
+			commandline.SetTo(encode->Text());
+			commandline.Append(" -y");
 
 			BString files_string;
 			files_string << sourcefile->Text() << " -> " << outputfile->Text();
@@ -716,7 +716,7 @@ void ffguiwin::MessageReceived(BMessage *message)
 
 
 			BMessage start_encode_message(M_RUN_COMMAND);
-			start_encode_message.AddString("cmdline", *commandline);
+			start_encode_message.AddString("cmdline", commandline);
 			fCommandLauncher->PostMessage(&start_encode_message);
 			encode_duration = 0;
 			encode_time = 0;

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -28,26 +28,18 @@
 
 void ffguiwin::BuildLine() // ask all the views what they hold, reset the command string
 {
-	char buff[64];
 	BString commandline("ffmpeg -i ");
-	const char *contents (sourcefile->Text()); //append the input file name
-	commandline.Append(contents);
-
-	sprintf(buff," -f %s",outputfileformat->MenuItem()->Label()); // grab and set the file format
-	commandline.Append(buff);
+	commandline << sourcefile->Text();  //append the input file name
+	commandline << " -f " << outputfileformat->MenuItem()->Label(); // grab and set the file format
 
 	if (benablevideo == false) // is video enabled, add options
 	{
-		sprintf(buff," -vcodec %s",outputvideoformat->MenuItem()->Label()); // grab and set the video encoder
-		commandline.Append(buff);
-		sprintf(buff," -b:v %d",(int)vbitrate->Value());
-		commandline.Append(buff);
-		sprintf(buff," -r %d",(int)framerate->Value());
-		commandline.Append(buff);
+		commandline << " -vcodec " << outputvideoformat->MenuItem()->Label(); // grab and set the video encoder
+		commandline << " -b:v " << vbitrate->Value();
+		commandline << " -r " << framerate->Value();
 		if (bcustomres == true)
 		{
-			sprintf(buff," -s %dx%d",(int)xres->Value(),(int)yres->Value());
-			commandline.Append(buff);
+			commandline << "-s " << xres->Value() << "x" << yres->Value();
 		}
 
 		// cropping options -- no point in cropping if we aren't encoding video...
@@ -55,52 +47,42 @@ void ffguiwin::BuildLine() // ask all the views what they hold, reset the comman
 		{
 			// below should be rewritten to use only one crop, but I can't be bothered
 			// to do so as ffmpeg supports multiple filters stacked on each other
-			if ((int)topcrop->Value() != 0)
+			if (topcrop->Value() != 0)
 			{
-				sprintf(buff," -vf crop=w=in_w:h=in_h:x=0:y=%d",(int)topcrop->Value());
-				commandline.Append(buff);
+				commandline << " -vf crop=w=in_w:h=in_h:x=0:y=" << topcrop->Value();
 			}
-			if ((int)bottomcrop->Value() != 0)
+			if (bottomcrop->Value() != 0)
 			{
-				sprintf(buff," -vf crop=w=in_w:h=in_h-%d:x=0:y=0",(int)bottomcrop->Value());
-				commandline.Append(buff);
+				commandline << " -vf crop=w=in_w:h=in_h-" << bottomcrop->Value() << ":x=0:y=0";
 			}
-			if ((int)leftcrop->Value() != 0)
+			if (leftcrop->Value() != 0)
 			{
-				sprintf(buff," -vf crop=w=in_w:h=in_h:x=%d:y=0",(int)leftcrop->Value());
-				commandline.Append(buff);
+				commandline << " -vf crop=w=in_w:h=in_h:x=" << leftcrop->Value() << ":y=0";
 			}
-			if ((int)rightcrop->Value() != 0)
+			if (rightcrop->Value() != 0)
 			{
-				sprintf(buff," -vf crop=w=in_w-%d:h=in_h:x=0:y=0",(int)rightcrop->Value());
-				commandline.Append(buff);
+				commandline << " -vf crop=w=in_w-" << rightcrop->Value() << ":h=in_h:x=0:y=0";
 			}
 		}
 	}
 	else //nope, add the no video encoding flag
 	{
-		commandline.Append(" -vn");
+		commandline << " -vn";
 	}
 
 	if (benableaudio == true) // audio encoding enabled, grab the values
 	{
-		sprintf(buff," -acodec %s",outputaudioformat->MenuItem()->Label());
-		commandline.Append(buff);
-		sprintf(buff," -b:a %d",(int)ab->Value());
-		commandline.Append(buff);
-		sprintf(buff," -ar %d",(int)ar->Value());
-		commandline.Append(buff);
-		sprintf(buff," -ac %d",(int)ac->Value());
-		commandline.Append(buff);
+		commandline << " -acodec " << outputaudioformat->MenuItem()->Label();
+		commandline << " -b:a " << ab->Value();
+		commandline << " -ar " << ar->Value();
+		commandline << " -ac " << ac->Value();
 	}
 	else
 	{
-		commandline.Append(" -an");
+		commandline << (" -an");
 	}
-	commandline.Append(" ");
-	commandline.Append(outputfile->Text());
-	printf(commandline.String());
-	printf("\n");
+	commandline << (" ");
+	commandline << (outputfile->Text());
 	encode->SetText(commandline.String());
 }
 

--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -109,7 +109,7 @@ class ffguiwin : public BWindow
 			bool benablevideo, benableaudio, benablecropping, bdeletesource,bcustomres;
 			bool sourcefile_specified, outputfile_specified;
 			// bstrings
-			BString *commandline;
+			BString commandline;
 			// file panels
 			BFilePanel *fSourceFilePanel;
 			BFilePanel *fOutputFilePanel;


### PR DESCRIPTION
This makes it possible to use file and/or folder names containing spaces. In the process I converted the ffguiwin::BuildLine() function to use the streaming functions of BString (<< operator) instead of c-style sprintf(). 

At least partially fixes #29 