### PR TITLE
Source file text control accepts file drops

### DIFF
--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -89,8 +89,6 @@ void ffguiwin::BuildLine() // ask all the views what they hold, reset the comman
 ffguiwin::ffguiwin(BRect r, char *name, window_type type, ulong mode)
 	: BWindow(r,name,type,mode)
 {
-	sourcefile_specified = false;
-	outputfile_specified = false;
 
 	//initialize GUI elements
 	sourcefilebutton = new BButton("Source file", new BMessage(M_SOURCE));
@@ -438,14 +436,12 @@ void ffguiwin::MessageReceived(BMessage *message)
 		case M_SOURCEFILE:
 		{
 			BuildLine();
-			sourcefile_specified = !(BString(sourcefile->Text()).Trim().IsEmpty());
 			set_encodebutton_state();
 			break;
 		}
 		case M_OUTPUTFILE:
 		{
 			BuildLine();
-			outputfile_specified = !(BString(outputfile->Text()).Trim().IsEmpty());
 			set_encodebutton_state();
 			break;
 		}
@@ -661,7 +657,6 @@ void ffguiwin::MessageReceived(BMessage *message)
 			BPath file_path(&file_entry);
 			sourcefile->SetText(file_path.Path());
 			BuildLine();
-			sourcefile_specified = true;
 			set_encodebutton_state();
 			break;
 		}
@@ -678,7 +673,6 @@ void ffguiwin::MessageReceived(BMessage *message)
 
 			outputfile->SetText(filename);
 			BuildLine();
-			outputfile_specified = true;
 			set_encodebutton_state();
 			break;
 		}
@@ -784,11 +778,9 @@ void ffguiwin::MessageReceived(BMessage *message)
 				message->FindRef("refs", &sourcefile_ref);
 				BEntry sourcefile_entry(&sourcefile_ref, true);
 				BPath sourcefile_path(&sourcefile_entry);
-
 				sourcefile->SetText(sourcefile_path.Path());
 				preset_outputfile();
 				BuildLine();
-				sourcefile_specified = true;
 				set_encodebutton_state();
 			}
 
@@ -811,7 +803,13 @@ void ffguiwin::set_encodebutton_state()
 {
 	bool encodebutton_enabled;
 
-	if (sourcefile_specified && outputfile_specified)
+	BString source_filename(sourcefile->Text());
+	BString output_filename(outputfile->Text());
+	source_filename.Trim();
+	output_filename.Trim();
+
+
+	if (!(source_filename.IsEmpty()) && !(output_filename.IsEmpty()))
 	{
 		encodebutton_enabled = true;
 	}

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -771,6 +771,28 @@ void ffguiwin::MessageReceived(BMessage *message)
 			fStatusBar->Hide();
 			break;
 		}
+		case B_SIMPLE_DATA:
+		{
+			BPoint drop_point;
+			message->FindPoint("_drop_point_", &drop_point);
+			BRect sourcefile_rect = sourcefile->Bounds();
+			sourcefile->ConvertToScreen(&sourcefile_rect);
+
+			if(sourcefile_rect.Contains(drop_point))
+			{
+				entry_ref sourcefile_ref;
+				message->FindRef("refs", &sourcefile_ref);
+				BEntry sourcefile_entry(&sourcefile_ref, true);
+				BPath sourcefile_path(&sourcefile_entry);
+
+				sourcefile->SetText(sourcefile_path.Path());
+				BuildLine();
+				sourcefile_specified = true;
+				set_encodebutton_state();
+			}
+
+			break;
+		}
 		default:
 			/*
 			printf("recieved by window:\n");

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -656,6 +656,7 @@ void ffguiwin::MessageReceived(BMessage *message)
 			BEntry file_entry(&ref, true);
 			BPath file_path(&file_entry);
 			sourcefile->SetText(file_path.Path());
+			preset_outputfile();
 			BuildLine();
 			set_encodebutton_state();
 			break;

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -786,6 +786,7 @@ void ffguiwin::MessageReceived(BMessage *message)
 				BPath sourcefile_path(&sourcefile_entry);
 
 				sourcefile->SetText(sourcefile_path.Path());
+				preset_outputfile();
 				BuildLine();
 				sourcefile_specified = true;
 				set_encodebutton_state();
@@ -841,5 +842,20 @@ ffguiwin::get_seconds(BString& time_string)
 	seconds+=hours*3600;
 
 	return seconds;
+
+}
+
+
+void
+ffguiwin::preset_outputfile()
+{
+	BString output_filename(sourcefile->Text());
+	int32 begin_ext = output_filename.FindLast(".")+1;
+	output_filename.RemoveChars(begin_ext, output_filename.Length()-begin_ext);
+	output_filename.Append(outputfileformatpopup->FindMarked()->Label());
+	outputfile->SetText(output_filename);
+
+
+
 
 }

--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -41,6 +41,7 @@ class ffguiwin : public BWindow
 
 	private:
 			void set_encodebutton_state();
+			void preset_outputfile();
 			int32 get_seconds(BString& time_string);
 
 			//main view

--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -108,7 +108,6 @@ class ffguiwin : public BWindow
 
 			// bools
 			bool benablevideo, benableaudio, benablecropping, bdeletesource,bcustomres;
-			bool sourcefile_specified, outputfile_specified;
 			// bstrings
 			BString commandline;
 			// file panels


### PR DESCRIPTION
Furthermore, if the source file is set via button or drag&drop, the output file is preset to the same name with the extension changed for the output file format.  