### PR TITLE
Resize spinners to fit the values

### DIFF
--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -410,6 +410,12 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 	.Layout();
 
 	ResizeToPreferred();
+	float min_width, min_height, max_width, max_height;
+	GetSizeLimits(&min_width, &max_width, &min_height, &max_height);
+	BSize window_size = Size();
+	min_width = window_size.width;
+	min_height = window_size.height;
+	SetSizeLimits(min_width, max_width, min_height, max_height);
 	MoveOnScreen();
 
 	fStatusBar->Hide();

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -224,6 +224,11 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 	ar->SetValue(44100);
 	ac->SetValue(2);
 
+	BSize ar_prefsize = ar->TextView()->PreferredSize();
+	ar_prefsize.width+=10;
+	ar->CreateTextViewLayoutItem()->SetExplicitMinSize(ar_prefsize);
+
+
 	// set the default status for the conditional spinners
 	benablecropping = true;
 	benableaudio = true;
@@ -858,3 +863,4 @@ ffguiwin::preset_outputfile()
 
 
 }
+

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -292,8 +292,12 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 		.End()
 		.Add(new BSeparatorView(B_HORIZONTAL))
 		.Add(customres)
-		.Add(xres)
-		.Add(yres);
+		.AddGrid(B_USE_SMALL_SPACING,B_USE_SMALL_SPACING)
+			.Add(xres->CreateLabelLayoutItem(),0,0)
+			.Add(xres->CreateTextViewLayoutItem(),1,0)
+			.Add(yres->CreateLabelLayoutItem(),0,1)
+			.Add(yres->CreateTextViewLayoutItem(),1,1)
+		.End();
 	videobox->AddChild(videolayout->View());
 
 	BBox *croppingoptionsbox = new BBox("");

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -222,12 +222,8 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 	yres->SetValue(720);
 	ab->SetValue(128);
 	ar->SetValue(44100);
+	set_preferred_spinner_size(ar);
 	ac->SetValue(2);
-
-	BSize ar_prefsize = ar->TextView()->PreferredSize();
-	ar_prefsize.width+=10;
-	ar->CreateTextViewLayoutItem()->SetExplicitMinSize(ar_prefsize);
-
 
 	// set the default status for the conditional spinners
 	benablecropping = true;
@@ -864,3 +860,14 @@ ffguiwin::preset_outputfile()
 
 }
 
+
+void
+ffguiwin::set_preferred_spinner_size(BSpinner *spinner)
+{
+
+	BSize textview_prefsize = spinner->TextView()->PreferredSize();
+	textview_prefsize.width+=20;
+	textview_prefsize.height=B_SIZE_UNSET;
+	spinner->CreateTextViewLayoutItem()->SetExplicitMinSize(textview_prefsize);
+
+}

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -222,8 +222,20 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 	yres->SetValue(720);
 	ab->SetValue(128);
 	ar->SetValue(44100);
-	set_preferred_spinner_size(ar);
 	ac->SetValue(2);
+
+	// set minimum size for the spinners
+	set_spinner_minsize(vbitrate);
+	set_spinner_minsize(framerate);
+	set_spinner_minsize(xres);
+	set_spinner_minsize(yres);
+	set_spinner_minsize(ab);
+	set_spinner_minsize(ar);
+	set_spinner_minsize(ac);
+	set_spinner_minsize(topcrop);
+	set_spinner_minsize(bottomcrop);
+	set_spinner_minsize(leftcrop);
+	set_spinner_minsize(rightcrop);
 
 	// set the default status for the conditional spinners
 	benablecropping = true;
@@ -862,7 +874,7 @@ ffguiwin::preset_outputfile()
 
 
 void
-ffguiwin::set_preferred_spinner_size(BSpinner *spinner)
+ffguiwin::set_spinner_minsize(BSpinner *spinner)
 {
 
 	BSize textview_prefsize = spinner->TextView()->PreferredSize();

--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -43,6 +43,7 @@ class ffguiwin : public BWindow
 			void set_encodebutton_state();
 			void preset_outputfile();
 			int32 get_seconds(BString& time_string);
+			void set_preferred_spinner_size(BSpinner *spinner);
 
 			//main view
 			BView *topview;

--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -43,7 +43,7 @@ class ffguiwin : public BWindow
 			void set_encodebutton_state();
 			void preset_outputfile();
 			int32 get_seconds(BString& time_string);
-			void set_preferred_spinner_size(BSpinner *spinner);
+			void set_spinner_minsize(BSpinner *spinner);
 
 			//main view
 			BView *topview;


### PR DESCRIPTION
The minimum required width plus a bit of extra space is set on all the spinners on the main options tab. Fixes #36 