### PR TITLE
Shorter crop options, slightly better About text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ OPTIMIZE :=
 # 	will recreate only the "locales/en.catkeys" file. Use it as a template
 # 	for creating catkeys for other languages. All localization files must be
 # 	placed in the "locales" subdirectory.
-LOCALES =
+LOCALES = de en
 
 #	Specify all the preprocessor symbols to be defined. The symbols will not
 #	have their values set automatically; you must supply the value (if any) to

--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,9 +1,11 @@
-1	English	application/x-vnd.HaikuArchives-ffmpegGUI	2475388938
+1	English	application/x-vnd.HaikuArchives-ffmpegGUI	132315271
 Main options	Window		Main options
 Video	Window		Video
 Deinterlace pictures	Window		Deinterlace pictures
 Enable audio encoding	Window		Enable audio encoding
+Start	Window		Start
 Use four motion vector	Window		Use four motion vector
+Encoding finished successfully.	Window		Encoding finished successfully.
 Output file format:	Window		Output file format:
 Calculate PSNR of compressed frames	Window		Calculate PSNR of compressed frames
 Output file	Window		Output file
@@ -15,31 +17,30 @@ Enable video cropping	Window		Enable video cropping
 Enable video encoding	Window		Enable video encoding
 Output	Window		Output
 Min video quantiser scale:	Window		Min video quantiser scale:
-Converting the video failed.	Window		Converting the video failed.
+Left:	Window		Left:
 Output audio format:	Window		Output audio format:
 Video quantiser scale compression:	Window		Video quantiser scale compression:
+Top:	Window		Top:
 About	Window		About
 GOP size:	Window		GOP size:
-Top crop size:	Window		Top crop size:
 App	Window		App
 Source file	Window		Source file
 Bitrate (Kbit/s):	Window		Bitrate (Kbit/s):
-Right crop size:	Window		Right crop size:
 Audio channels:	Window		Audio channels:
-The video was converted successfully.	Window		The video was converted successfully.
 Advanced options	Window		Advanced options
-Bottom crop size:	Window		Bottom crop size:
 Quit	Window		Quit
 Height:	Window		Height:
 Video quantiser scale blur:	Window		Video quantiser scale blur:
 Framerate (fps):	Window		Framerate (fps):
+Thanks to:\nmmu_man, Jeremy, DeadYak, Marco, etc.\nmd@geekport.com\nreds <reds@sakamoto.pl> for making it more or less usable.\nHave fun!	Application		Thanks to:\nmmu_man, Jeremy, DeadYak, Marco, etc.\nmd@geekport.com\nreds <reds@sakamoto.pl> for making it more or less usable.\nHave fun!
 Use high quality settings	Window		Use high quality settings
 File options	Window		File options
-Thanks to mmu_man, Jeremy, DeadYak, Marco, etc...\nmd@geekport.com\nmade more or less usable by reds <reds@sakamoto.pl> - have fun!	Application		Thanks to mmu_man, Jeremy, DeadYak, Marco, etc...\nmd@geekport.com\nmade more or less usable by reds <reds@sakamoto.pl> - have fun!
+Bottom:	Window		Bottom:
+Right:	Window		Right:
 Max difference between quantiser scale:	Window		Max difference between quantiser scale:
+Encoding failed.	Window		Encoding failed.
 Encode	Window		Encode
 Max video quantiser scale:	Window		Max video quantiser scale:
-Left crop size:	Window		Left crop size:
 Audio	Window		Audio
 Cropping options	Window		Cropping options
 Waiting to start encoding…	Window		Waiting to start encoding…

--- a/source/ffgui-application.cpp
+++ b/source/ffgui-application.cpp
@@ -70,9 +70,11 @@ ffguiapp::AboutRequested()
 	};
 
 	BString extra_info;
-	extra_info << 	B_TRANSLATE("Thanks to mmu_man, Jeremy, DeadYak, Marco, etc...\n"
+	extra_info << 	B_TRANSLATE("Thanks to:\n"
+					"mmu_man, Jeremy, DeadYak, Marco, etc.\n"
 					"md@geekport.com\n"
-					"made more or less usable by reds <reds@sakamoto.pl> - have fun!");
+					"reds <reds@sakamoto.pl> for making it more or less usable.\n"
+					"Have fun!");
 
 	aboutwindow->AddCopyright(2003, "Zach Dykstra");
 	aboutwindow->AddAuthors(authors);

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -140,10 +140,10 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 
 	enablecropping = new BCheckBox("", B_TRANSLATE("Enable video cropping"), new BMessage(M_ENABLECROPPING));
 	enablecropping->SetValue(B_CONTROL_ON);
-	topcrop = new BSpinner("", B_TRANSLATE("Top crop size:"), new BMessage(M_TOPCROP));
-	bottomcrop = new BSpinner("", B_TRANSLATE("Bottom crop size:"), new BMessage(M_BOTTOMCROP));
-    leftcrop = new BSpinner("", B_TRANSLATE("Left crop size:"), new BMessage(M_LEFTCROP));
-	rightcrop = new BSpinner("", B_TRANSLATE("Right crop size:"), new BMessage(M_RIGHTCROP));
+	topcrop = new BSpinner("", B_TRANSLATE("Top:"), new BMessage(M_TOPCROP));
+	bottomcrop = new BSpinner("", B_TRANSLATE("Bottom:"), new BMessage(M_BOTTOMCROP));
+    leftcrop = new BSpinner("", B_TRANSLATE("Left:"), new BMessage(M_LEFTCROP));
+	rightcrop = new BSpinner("", B_TRANSLATE("Right:"), new BMessage(M_RIGHTCROP));
 
 	enableaudio = new BCheckBox("", B_TRANSLATE("Enable audio encoding"), new BMessage(M_ENABLEAUDIO));
 	enableaudio->SetValue(B_CONTROL_ON);
@@ -169,7 +169,7 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 	outputtext->SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
 	outputtext->MakeEditable(false);
 
-	encodebutton = new BButton(B_TRANSLATE("Encode"), new BMessage(M_ENCODE));
+	encodebutton = new BButton(B_TRANSLATE("Start"), new BMessage(M_ENCODE));
 	encodebutton->SetEnabled(false);
 	encode = new BTextControl("", "", nullptr);
 
@@ -783,11 +783,11 @@ void ffguiwin::MessageReceived(BMessage *message)
 			BString finished_message;
 			if(exit_code == 0)
 			{
-				finished_message = B_TRANSLATE("The video was converted successfully.");
+				finished_message = B_TRANSLATE("Encoding finished successfully.");
 			}
 			else
 			{
-				finished_message << B_TRANSLATE("Converting the video failed.");
+				finished_message << B_TRANSLATE("Encoding failed.");
 			}
 
 			BAlert *finished_alert = new BAlert("", finished_message, B_TRANSLATE("OK"));


### PR DESCRIPTION
* As it's all under "Cropping options", shorten "Top crop size" etc. to simply "Top".
* Slightly improved wording of the thanks in the About window.
* Updated en.catkeys