### PR TITLE
Set default location/filename for output dialog

### DIFF
--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -621,6 +621,12 @@ void ffguiwin::MessageReceived(BMessage *message)
 		}
 		case M_OUTPUT:
 		{
+			BPath path = outputfile->Text();
+			if (path.InitCheck() == B_OK) {
+				fOutputFilePanel->SetSaveText(path.Leaf());
+				path.GetParent(&path);
+				fOutputFilePanel->SetPanelDirectory(path.Path());
+			}
 			fOutputFilePanel->Show();
 			break;
 		}


### PR DESCRIPTION
If you click on the "Output file" button, set the dialog's location/filename with the output text field's path (if it has been set e.g. when the "Source file" was set).