### PR TITLE
Rename executable to ffmpegGUI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 ## architecture of Haiku.
 
 # The name of the binary.
-NAME = ffgui
+NAME = ffmpegGUI
 
 # The type of binary, must be one of:
 #	APP:	Application

--- a/source/ffgui-application.cpp
+++ b/source/ffgui-application.cpp
@@ -31,7 +31,7 @@ ffguiapp::ffguiapp()
 	: BApplication(kAppSignature)
 {
 	ffguiwin *window;
-	window = new ffguiwin(BRect(0,0,0,0),B_TRANSLATE_SYSTEM_NAME("ffmpeg GUI"),B_TITLED_WINDOW,B_NOT_V_RESIZABLE);
+	window = new ffguiwin(BRect(0,0,0,0),B_TRANSLATE_SYSTEM_NAME("ffmpegGUI"),B_TITLED_WINDOW,B_NOT_V_RESIZABLE);
 	window->Show();
 }
 
@@ -52,7 +52,7 @@ void ffguiapp::MessageReceived(BMessage *message)
 void
 ffguiapp::AboutRequested()
 {
-	BAboutWindow *aboutwindow = new BAboutWindow(B_TRANSLATE_SYSTEM_NAME("ffmpeg GUI"), kAppSignature);
+	BAboutWindow *aboutwindow = new BAboutWindow(B_TRANSLATE_SYSTEM_NAME("ffmpegGUI"), kAppSignature);
 
 	const char *authors[] =
 	{


### PR DESCRIPTION
For most Haiku apps the executable is named after the name of the app. Let's do that too. 
Fixes #52 
This is a really big PR with lots of changes, so test and review carefully before merging ;-) ;-)