### PR TITLE
Implement a "Stop" button to abort encoding

### DIFF
--- a/source/commandlauncher.h
+++ b/source/commandlauncher.h
@@ -11,6 +11,11 @@ enum {
 	INFO
 };
 
+enum {
+	SUCCESS = 0,
+	FAILED ,
+	ABORTED
+};
 
 class CommandLauncher : public BLooper{
 public:
@@ -18,7 +23,8 @@ public:
 	void MessageReceived(BMessage *message);
 
 private:
-	void run_command();
+	static status_t		_ffmpeg_command(void* self);
+	void 				run_command();
 
 	BString 	fCmdline;
 	BMessage	*fOutputMessage;
@@ -26,6 +32,8 @@ private:
 	BMessenger	*fTargetMessenger;
 	bool 		fBusy;
 	int32		fCommandFlag;
+	thread_id	fThread;
+	status_t	fErrorCode;
 };
 
 #endif

--- a/source/messages.h
+++ b/source/messages.h
@@ -17,8 +17,9 @@ const uint32 M_NOMSG = 0x00000000;
 const uint32 M_SOURCE = 0x1100;
 const uint32 M_OUTPUT = 0x1101;
 const uint32 M_ENCODE = 0x1102;
-const uint32 M_PLAY_SOURCE = 0x1103;
-const uint32 M_PLAY_OUTPUT = 0x1104;
+const uint32 M_STOP_ENCODING = 0x1103;
+const uint32 M_PLAY_SOURCE = 0x1104;
+const uint32 M_PLAY_OUTPUT = 0x1105;
 
 // Spinners
 const uint32 M_VBITRATE = 0x1200;
@@ -63,5 +64,6 @@ const uint32 M_ENCODE_FINISHED = 0x1702;
 const uint32 M_INFO_COMMAND = 0x1703;
 const uint32 M_INFO_OUTPUT = 0x1704;
 const uint32 M_INFO_FINISHED = 0x1705;
+const uint32 M_STOP_COMMAND = 0x1706;
 
 #endif


### PR DESCRIPTION
* The "Encode" button toggles to "Stop" when encoding was started.

* Pressing "Stop" will kill the ffmpeg command thread.

* Only show a notification for success or failure, not the user initiated aborting.

* To avoid having run_command() block the MessageReceived() of CommandLauncher, spawn it in a thread.