### PR TITLE
Progresss bar: Re-use clip duration from getting media info

### DIFF
--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -118,7 +118,6 @@ class ffguiwin : public BWindow
 			//progress bar
 			int32 encode_duration;
 			int32 encode_time;
-			bool duration_detected;
 			BCheckBox *fPlayCheck;
 			BStatusBar *fStatusBar;
 


### PR DESCRIPTION
As we already got the duration in seconds from running ffprobe to get the media info, re-use it for the progress bar.

Besides simplifying the code, it also fixes some instances where the progress bar would be stuck at 0% when parsing the ffmpeg output for "Duration:" failed for some reason.