### PR TITLE
Confirmation to stop encoding

### DIFF
--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -13,12 +13,14 @@
 	Andi Machovec (BlueSky), andi.machovec@gmail.com, 2022
 */
 
+#include <Invoker.h>
 #include <Window.h>
 
 
 class BView;
 class BTextView;
 class BTextControl;
+class BAlert;
 class BButton;
 class BSpinner;
 class BCheckBox;
@@ -121,6 +123,7 @@ class ffguiwin : public BWindow
 			bool duration_detected;
 			BCheckBox *fPlayCheck;
 			BStatusBar *fStatusBar;
+			time_t encode_starttime;
 
 			//menu bar
 			BMenuBar *fTopMenuBar;
@@ -148,8 +151,11 @@ class ffguiwin : public BWindow
 			BFilePanel *fSourceFilePanel;
 			BFilePanel *fOutputFilePanel;
 
-			CommandLauncher *fCommandLauncher;
+			// alerts
+			BAlert* fStopAlert;
+			BInvoker fAlertInvoker;
 
+			CommandLauncher *fCommandLauncher;
 };
 
 #endif

--- a/source/messages.h
+++ b/source/messages.h
@@ -66,4 +66,7 @@ const uint32 M_INFO_OUTPUT = 0x1704;
 const uint32 M_INFO_FINISHED = 0x1705;
 const uint32 M_STOP_COMMAND = 0x1706;
 
+//Misc
+const uint32 M_STOP_ALERT_BUTTON = 0x1800;
+
 #endif


### PR DESCRIPTION
Show an alert asking for confirmation to abort the encoding if the encoding has been running for more than 30 seconds.

Below that time, a confirmation alert would be more of an annoyance than having to re-start the encoding if "Stop" was pressed accidentally.

Show alert asynchronously to keep updating the progress bar.

Change alert text and button label if the encoding has finished before the user clicked a button... :)