### PR TITLE
Introduce a floating point spinner for framerates

### DIFF
--- a/source/ffgui-spinner.cpp
+++ b/source/ffgui-spinner.cpp
@@ -35,3 +35,55 @@ ffguispinner::SetStep(int32 step)
 	fStep = step;
 
 }
+
+
+// Spinner for floating point
+
+ffguidecspinner::ffguidecspinner(const char* name, const char* label, BMessage* message)
+	:
+	BDecimalSpinner(name, label, message)
+{
+	SetPrecision(0);
+}
+
+
+void
+ffguidecspinner::Increment()
+{
+	double value = Value();
+	// show 'special' framerates as 23.976, 29.97, 59.97
+	if (value >= 23 && value < 24 / 1.001) {
+		SetPrecision(3);
+		SetValue(24 / 1.001);
+	} else if (value >= 29.0 && value < 30 / 1.001) {
+		SetPrecision(2);
+		SetValue(30 / 1.001);
+	} else if (value >= 59.0 && value < 60 / 1.001) {
+		SetPrecision(2);
+		SetValue(60 / 1.001);
+	} else {
+		SetPrecision(0);
+		SetValue(truncf(Value() + 1.0));
+	}
+}
+
+
+void
+ffguidecspinner::Decrement()
+{
+	double value = Value();
+	// show 'special' framerates as 23.976, 29.97, 59.97
+	if (value <= 24 && value > 24 / 1.001) {
+		SetPrecision(3);
+		SetValue(24 / 1.001);
+	} else if (value <= 30.0 && value > 30 / 1.001) {
+		SetPrecision(2);
+		SetValue(30 / 1.001);
+	} else if (value <= 59.0 && value > 60 / 1.001) {
+		SetPrecision(2);
+		SetValue(60 / 1.001);
+	} else {
+		SetPrecision(0);
+		SetValue(ceilf(Value()) - 1.0);
+	}
+}

--- a/source/ffgui-spinner.h
+++ b/source/ffgui-spinner.h
@@ -1,6 +1,7 @@
 #ifndef FFGUI_SPINNER_H
 #define FFGUI_SPINNER_H
 
+#include "DecimalSpinner.h"
 #include "Spinner.h"
 
 class ffguispinner : public BSpinner {
@@ -12,6 +13,15 @@ public:
 
 private:
 	int32 fStep;
+
+};
+
+
+class ffguidecspinner : public BDecimalSpinner {
+public:
+	ffguidecspinner(const char* name, const char* label, BMessage* message);
+	void Increment();
+	void Decrement();
 
 };
 

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -181,7 +181,7 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 	enablevideo = new BCheckBox("", B_TRANSLATE("Enable video encoding"), new BMessage(M_ENABLEVIDEO));
 	enablevideo->SetValue(B_CONTROL_ON);
 	vbitrate = new ffguispinner("", B_TRANSLATE("Bitrate (Kbit/s):"), new BMessage(M_VBITRATE));
-	framerate = new ffguispinner("", B_TRANSLATE("Framerate (fps):"), new BMessage(M_FRAMERATE));
+	framerate = new ffguidecspinner("", B_TRANSLATE("Framerate (fps):"), new BMessage(M_FRAMERATE));
 	customres = new BCheckBox("", B_TRANSLATE("Use custom resolution"), new BMessage(M_CUSTOMRES));
 	xres = new ffguispinner("", B_TRANSLATE("Width:"), new BMessage(M_XRES));
 	yres = new ffguispinner("", B_TRANSLATE("Height:"), new BMessage(M_YRES));
@@ -261,7 +261,7 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 	vbitrate->SetMinValue(64);
 	vbitrate->SetMaxValue(50000);
 	framerate->SetMinValue(1);
-	framerate->SetMaxValue(60);
+	framerate->SetMaxValue(120);
 	xres->SetMinValue(160);
 	xres->SetMaxValue(7680);
 	yres->SetMinValue(120);
@@ -1138,6 +1138,17 @@ ffguiwin::set_spinner_minsize(BSpinner *spinner)
 	textview_prefsize.height=B_SIZE_UNSET;
 	spinner->CreateTextViewLayoutItem()->SetExplicitMinSize(textview_prefsize);
 }
+
+
+void
+ffguiwin::set_spinner_minsize(BDecimalSpinner *spinner)
+{
+	BSize textview_prefsize = spinner->TextView()->PreferredSize();
+	textview_prefsize.width+=20;
+	textview_prefsize.height=B_SIZE_UNSET;
+	spinner->CreateTextViewLayoutItem()->SetExplicitMinSize(textview_prefsize);
+}
+
 
 void
 ffguiwin::play_video(const char* filepath)

--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -20,6 +20,7 @@ class BView;
 class BTextView;
 class BTextControl;
 class BButton;
+class BDecimalSpinner;
 class BSpinner;
 class BCheckBox;
 class BPopUpMenu;
@@ -32,6 +33,7 @@ class BString;
 class BStringView;
 class CommandLauncher;
 class ffguispinner;
+class ffguidecspinner;
 
 
 class ffguiwin : public BWindow
@@ -55,6 +57,7 @@ class ffguiwin : public BWindow
 			void set_outputfile_extension();
 			int32 get_seconds(BString& time_string);
 			void set_spinner_minsize(BSpinner *spinner);
+			void set_spinner_minsize(BDecimalSpinner *spinner);
 			void play_video(const char* filepath);
 			//main view
 			BView *topview;
@@ -73,7 +76,7 @@ class ffguiwin : public BWindow
 			BButton *encodebutton;
 			// spin buttons
 			ffguispinner *vbitrate;
-			ffguispinner *framerate;
+			ffguidecspinner *framerate;
 			ffguispinner *xres;
 			ffguispinner *yres;
 			ffguispinner *topcrop;


### PR DESCRIPTION
* To be able to show 'broadcast framerates (23.976, 29.97, 59.97) we use a BDecimalSpinner.

* Show the ret of the framerates as integers.

* Allow framerates up to 120 fps.

Fixes #71