### PR TITLE
Add BAlert to confirm quitting while encoding in progress

### DIFF
--- a/source/messages.h
+++ b/source/messages.h
@@ -68,5 +68,6 @@ const uint32 M_STOP_COMMAND = 0x1706;
 
 //Misc
 const uint32 M_STOP_ALERT_BUTTON = 0x1800;
+const uint32 M_QUIT_ALERT_BUTTON = 0x1801;
 
 #endif


### PR DESCRIPTION
An encoding_starttime of "0", means no encoding is in progress. If an encoding is running, ask if to abort it when asked to quit and stop the encoding if the user does want to quit.