### PR TITLE
Use video/audio values of source file, add "Default options"

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.HaikuArchives-ffmpegGUI	2039973223
+1	English	application/x-vnd.HaikuArchives-ffmpegGUI	2853809895
 Deinterlace pictures	Window		Deinterlace pictures
 Min video quantizer scale:	Window		Min video quantizer scale:
 Copy commandline	Window		Copy commandline
@@ -14,6 +14,7 @@ Cannot overwrite the source file. Please choose another output file name.	Window
 GOP size:	Window		GOP size:
 Bitrate (Kbit/s):	Window		Bitrate (Kbit/s):
 Audio channels:	Window		Audio channels:
+Stop encoding	Window		Stop encoding
 Please select a source file.	Window		Please select a source file.
 About ffmpegGUI	Window		About ffmpegGUI
 Quit	Window		Quit
@@ -51,6 +52,7 @@ Top:	Window		Top:
 Encoding	Window		Encoding
 Source file	Window		Source file
 Play source file	Window		Play source file
+Default options	Window		Default options
 Max difference between quantizer scale:	Window		Max difference between quantizer scale:
 Video quantizer scale blur:	Window		Video quantizer scale blur:
 Max video quantizer scale:	Window		Max video quantizer scale:

--- a/source/ffgui-spinner.cpp
+++ b/source/ffgui-spinner.cpp
@@ -51,16 +51,16 @@ void
 ffguidecspinner::Increment()
 {
 	double value = Value();
-	// show 'special' framerates as 23.976, 29.97, 59.97
-	if (value >= 23 && value < 24 / 1.001) {
+	// show 'special' framerates as 24/1.001, 30/1.001, 60/1.001
+	if (value >= 23 && value < 23.976) {
 		SetPrecision(3);
-		SetValue(24 / 1.001);
-	} else if (value >= 29.0 && value < 30 / 1.001) {
+		SetValue(23.976);
+	} else if (value >= 29.0 && value < 29.97) {
 		SetPrecision(2);
-		SetValue(30 / 1.001);
-	} else if (value >= 59.0 && value < 60 / 1.001) {
+		SetValue(29.97);
+	} else if (value >= 59.0 && value < 59.97) {
 		SetPrecision(2);
-		SetValue(60 / 1.001);
+		SetValue(59.97);
 	} else {
 		SetPrecision(0);
 		SetValue(truncf(Value() + 1.0));
@@ -72,16 +72,16 @@ void
 ffguidecspinner::Decrement()
 {
 	double value = Value();
-	// show 'special' framerates as 23.976, 29.97, 59.97
-	if (value <= 24 && value > 24 / 1.001) {
+	// show 'special' framerates as 24/1.001, 30/1.001, 60/1.001
+	if (value <= 24 && value > 23.976) {
 		SetPrecision(3);
-		SetValue(24 / 1.001);
-	} else if (value <= 30.0 && value > 30 / 1.001) {
+		SetValue(23.976);
+	} else if (value <= 30.0 && value > 29.97) {
 		SetPrecision(2);
-		SetValue(30 / 1.001);
-	} else if (value <= 59.0 && value > 60 / 1.001) {
+		SetValue(29.97);
+	} else if (value <= 59.0 && value > 59.97) {
 		SetPrecision(2);
-		SetValue(60 / 1.001);
+		SetValue(59.97);
 	} else {
 		SetPrecision(0);
 		SetValue(ceilf(Value()) - 1.0);

--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -50,6 +50,8 @@ class ffguiwin : public BWindow
 	private:
 			void get_media_info();
 			void parse_media_output();
+			void adopt_defaults();
+			void set_defaults();
 			void update_media_info();
 			void remove_over_precision(BString& float_string);
 			void set_playbuttons_state();
@@ -61,6 +63,12 @@ class ffguiwin : public BWindow
 			void set_spinner_minsize(BSpinner *spinner);
 			void set_spinner_minsize(BDecimalSpinner *spinner);
 			void play_video(const char* filepath);
+			void toggle_video();
+			void toggle_custom_resolution();
+			void toggle_cropping();
+			void toggle_audio();
+
+
 			//main view
 			BView *topview;
 			// text views
@@ -133,9 +141,7 @@ class ffguiwin : public BWindow
 			BMenuItem* fMenuPlayOutput;
 			BMenuItem* fMenuStartEncode;
 			BMenuItem* fMenuStopEncode;
-
-			// bools
-			bool benablevideo, benableaudio, benablecropping, bdeletesource,bcustomres;
+			BMenuItem* fMenuDefaults;
 
 			// bstrings
 			BString commandline;
@@ -151,6 +157,7 @@ class ffguiwin : public BWindow
 			BString fVideoBitrate;
 			BString fAudioBitrate;
 			BString fAudioSamplerate;
+			BString fAudioChannels;
 			BString fAudioChannelLayout;
 
 			// file panels


### PR DESCRIPTION
* When opening a source file, adopt its video bitrate, frames/s, audio samplerate and number of channels as defaults.

  Don't adopt audio bitrate, as there are many clips with 'non-standard' values around and which bitrate should we choose from the menu then?

* Added a few more common audio bitrate values to the pop-up menu.

* Use absolute values like 23.976 instead of 24/1.001 to avoid rounding errors that can spoil in/decrease actions when inserting a value of a dropped source file.

* Add menu item "Default options" that'll reset all options to the default. Then the source file values are adopted.

* Simplified checkbox logic

* Got rid of the bool flags and the value from the ceckbox directly.