### PR TITLE
Move dropdown controls for video and audio codec to the respective boxes

### DIFF
--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -83,13 +83,13 @@ void ffguiwin::BuildLine() // ask all the views what they hold, reset the comman
 	commandline << " -f " << fileformat_option; // grab and set the file format
 
 	// is video enabled, add options
-	if (outputvideoformatpopup->FindMarkedIndex() == 0)
+	if (enablevideo->Value() == B_CONTROL_ON)
 	{
-		commandline << " -vcodec copy";
-	}
-	else
-	{
-		if ((enablevideo->IsEnabled()) and (enablevideo->Value() == B_CONTROL_ON))
+		if (outputvideoformatpopup->FindMarkedIndex() == 0)
+		{
+			commandline << " -vcodec copy";
+		}
+		else
 		{
 			commandline << " -vcodec " << outputvideoformat->MenuItem()->Label();
 			commandline << " -b:v " << vbitrate->Value() << "k";
@@ -107,30 +107,30 @@ void ffguiwin::BuildLine() // ask all the views what they hold, reset the comman
 							<< leftcrop->Value() << ":" << topcrop->Value();
 			}
 		}
-		else
-		{
-			commandline << " -vn";
-		}
-	}
-
-	// audio encoding enabled, grab the values
-	if (outputaudioformatpopup->FindMarkedIndex() == 0)
-	{
-		commandline << " -acodec copy";
 	}
 	else
 	{
-		if ((enableaudio->IsEnabled()) and (enableaudio->Value() == B_CONTROL_ON))
+		commandline << " -vn";
+	}
+
+	// audio encoding enabled, grab the values
+	if (enableaudio->Value() == B_CONTROL_ON)
+	{
+		if (outputaudioformatpopup->FindMarkedIndex() == 0)
+		{
+			commandline << " -acodec copy";
+		}
+		else
 		{
 			commandline << " -acodec " << outputaudioformat->MenuItem()->Label();
 			commandline << " -b:a " << std::atoi(abpopup->FindMarked()->Label()) << "k";
 			commandline << " -ar " << std::atoi(arpopup->FindMarked()->Label());
 			commandline << " -ac " << ac->Value();
 		}
-		else
-		{
-			commandline << (" -an");
-		}
+	}
+	else
+	{
+		commandline << (" -an");
 	}
 
 	commandline << " \"" << output_filename << "\"";

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -1378,7 +1378,7 @@ ffguiwin::toggle_cropping()
 {
 
 	//disable cropping if video options are not enabled;
-	if ((enablevideo->IsEnabled()) and (enablevideo->Value() == B_CONTROL_ON))
+	if ((enablevideo->IsEnabled()) and (enablevideo->Value() == B_CONTROL_ON) and (outputvideoformatpopup->FindMarkedIndex() != 0))
 	{
 		enablecropping->SetEnabled(true);
 	}

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -1342,21 +1342,21 @@ ffguiwin::play_video(const char* filepath)
 void
 ffguiwin::toggle_video()
 {
-	//disable video options if audio codec copy is selected
-	if (outputvideoformatpopup->FindMarkedIndex() == 0)
-	{
-		enablevideo->SetEnabled(false);
-	}
-	else
-	{
-		enablevideo->SetEnabled(true);
-	}
-
 	bool video_options_enabled;
-	if ((enablevideo->IsEnabled()) and (enablevideo->Value() == B_CONTROL_ON))
-		video_options_enabled = true;
+
+	if (enablevideo->Value() == B_CONTROL_ON)
+	{
+		outputvideoformat->SetEnabled(true);
+		if (outputvideoformatpopup->FindMarkedIndex() != 0)
+			video_options_enabled = true;
+		else
+			video_options_enabled = false;
+	}
 	else
+	{
+		outputvideoformat->SetEnabled(false);
 		video_options_enabled = false;
+	}
 
 	vbitrate->SetEnabled(video_options_enabled);
 	framerate->SetEnabled(video_options_enabled);

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -199,7 +199,7 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 	outputvideoformatpopup->AddItem(new BMenuItem("vp9", new BMessage(M_OUTPUTVIDEOFORMAT)));
 	outputvideoformatpopup->AddItem(new BMenuItem("wmv1", new BMessage(M_OUTPUTVIDEOFORMAT)));
 	outputvideoformatpopup->ItemAt(0)->SetMarked(true);
-	outputvideoformat = new BMenuField(B_TRANSLATE("Output video format:"), outputvideoformatpopup);
+	outputvideoformat = new BMenuField(B_TRANSLATE("Video codec:"), outputvideoformatpopup);
 	menuWidth = outputvideoformat->PreferredSize();
 	menuWidth.height=B_SIZE_UNSET;
 	outputvideoformat->SetExplicitMinSize(menuWidth);
@@ -211,7 +211,7 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 	outputaudioformatpopup->AddItem(new BMenuItem("opus", new BMessage(M_OUTPUTAUDIOFORMAT)));
 	outputaudioformatpopup->AddItem(new BMenuItem("vorbis", new BMessage(M_OUTPUTAUDIOFORMAT)));
 	outputaudioformatpopup->ItemAt(0)->SetMarked(true);
-	outputaudioformat = new BMenuField(B_TRANSLATE("Output audio format:"), outputaudioformatpopup);
+	outputaudioformat = new BMenuField(B_TRANSLATE("Audio codec:"), outputaudioformatpopup);
 	menuWidth = outputaudioformat->PreferredSize();
 	menuWidth.height=B_SIZE_UNSET;
 	outputaudioformat->SetExplicitMinSize(menuWidth);
@@ -352,10 +352,7 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 		.End()
 		.AddGroup(B_HORIZONTAL)
 			.Add(outputfileformat)
-			.AddStrut(B_USE_SMALL_SPACING)
-			.Add(outputvideoformat)
-			.AddStrut(B_USE_SMALL_SPACING)
-			.Add(outputaudioformat)
+			.AddGlue()
 		.End();
 
 	BView *encodeview = new BView("encodeview", B_SUPPORTS_LAYOUT);
@@ -373,6 +370,7 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 		.SetInsets(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING,
 					B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING)
 		.Add(enablevideo)
+		.Add(outputvideoformat)
 		.AddGrid(B_USE_SMALL_SPACING,B_USE_SMALL_SPACING)
 			.Add(vbitrate->CreateLabelLayoutItem(),0,0)
 			.Add(vbitrate->CreateTextViewLayoutItem(),1,0)
@@ -414,6 +412,7 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 		.SetInsets(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING,
 					B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING)
 		.Add(enableaudio)
+		.Add(outputaudioformat)
 		.AddGrid(B_USE_SMALL_SPACING,B_USE_SMALL_SPACING)
 			.Add(ab->CreateLabelLayoutItem(),0,0)
 			.Add(ab->CreateMenuBarLayoutItem(),1,0)

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -1409,21 +1409,23 @@ void
 ffguiwin::toggle_audio()
 {
 
-	//disable audio options if audio codec copy is selected
-	if (outputaudioformatpopup->FindMarkedIndex() == 0)
-	{
-		enableaudio->SetEnabled(false);
-	}
-	else
-	{
-		enableaudio->SetEnabled(true);
-	}
 
 	bool audio_options_enabled;
-	if ((enableaudio->IsEnabled()) and (enableaudio->Value() == B_CONTROL_ON))
-		audio_options_enabled = true;
+	if (enableaudio->Value() == B_CONTROL_ON)
+	{
+		outputaudioformat->SetEnabled(true);
+
+
+		if (outputaudioformatpopup->FindMarkedIndex() != 0)
+			audio_options_enabled = true;
+		else
+			audio_options_enabled = false;
+	}
 	else
+	{
+		outputaudioformat->SetEnabled(false);
 		audio_options_enabled = false;
+	}
 
 	ab->SetEnabled(audio_options_enabled);
 	ac->SetEnabled(audio_options_enabled);


### PR DESCRIPTION
Moving the codec selection below the enable/disable checkboxes for video and audio makes it much easier to disable video or audio streams for encoding. 
@humdingerb: What do you think? 