### PR TITLE
Organize container formats, audio and video codecs in containers

### DIFF
--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -1478,6 +1478,8 @@ ffguiwin::populate_codec_options()
 	fContainerFormats.push_back(ContainerOption("webm","webm","WebM", CAP_AUDIO_VIDEO));
 	fContainerFormats.push_back(ContainerOption("flac","flac","FLAC", CAP_AUDIO_ONLY));
 	fContainerFormats.push_back(ContainerOption("mp3","mp3","MPEG audio layer 3", CAP_AUDIO_ONLY));
+	fContainerFormats.push_back(ContainerOption("oga","oga","Ogg Audio", CAP_AUDIO_ONLY));
+	fContainerFormats.push_back(ContainerOption("wav","wav","WAV/WAVE (Waveform Audio)", CAP_AUDIO_ONLY));
 
 	// video codecs
 	fVideoCodecs.push_back(CodecOption("copy","1:1 copy"));
@@ -1487,14 +1489,15 @@ ffguiwin::populate_codec_options()
 	fVideoCodecs.push_back(CodecOption("vp9","Google VP9"));
 	fVideoCodecs.push_back(CodecOption("wmv1","Windows Media Video 7"));
 	fVideoCodecs.push_back(CodecOption("wmv2","Windows Media Video 8"));
-	//fVideoCodecs.push_back(CodecOption("",""));
+	fVideoCodecs.push_back(CodecOption("mjpeg","Motion JPEG"));
 
 	//audio codecs
 	fAudioCodecs.push_back(CodecOption("copy","1:1 copy"));
-	fAudioCodecs.push_back(CodecOption("aac","AAC (Advanced Audio Coding"));
+	fAudioCodecs.push_back(CodecOption("aac","AAC (Advanced Audio Coding)"));
 	fAudioCodecs.push_back(CodecOption("ac3","ATSC A/52A (AC-3)"));
 	fAudioCodecs.push_back(CodecOption("libvorbis","Vorbis"));
 	fAudioCodecs.push_back(CodecOption("flac","FLAC (Free Lossless Audio Codec)"));
-	//fAudioCodecs.push_back(CodecOption("",""));
-
+	fAudioCodecs.push_back(CodecOption("dts","DCA (DTS Coherent Acoustics)"));
+	fAudioCodecs.push_back(CodecOption("mp3","MPEG audio layer 3"));
+	fAudioCodecs.push_back(CodecOption("pcm_s16le","PCM signed 16-bit little endian"));
 }

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -659,6 +659,7 @@ void ffguiwin::MessageReceived(BMessage *message)
 			else
 				enablevideo->SetEnabled(true);
 
+			toggle_video();
 			BuildLine();
 			break;
 		}
@@ -1373,7 +1374,7 @@ ffguiwin::toggle_video()
 {
 	bool video_options_enabled;
 
-	if (enablevideo->Value() == B_CONTROL_ON)
+	if ((enablevideo->Value() == B_CONTROL_ON) and (enablevideo->IsEnabled()))
 	{
 		outputvideoformat->SetEnabled(true);
 		if (outputvideoformatpopup->FindMarkedIndex() != 0)

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -215,9 +215,10 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 	}
 	outputvideoformatpopup->ItemAt(0)->SetMarked(true);
 	outputvideoformat = new BMenuField(B_TRANSLATE("Video codec:"), outputvideoformatpopup);
-	menuWidth = outputvideoformat->PreferredSize();
-	menuWidth.height=B_SIZE_UNSET;
-	outputvideoformat->SetExplicitMinSize(menuWidth);
+	float popup_width;
+	outputvideoformatpopup->GetPreferredSize(&popup_width, nullptr);
+	outputvideoformat->CreateMenuBarLayoutItem()->SetExplicitMinSize(BSize(popup_width, B_SIZE_UNSET));
+
 
 	outputaudioformatpopup = new BPopUpMenu("");
 	for (codec_iter=fAudioCodecs.begin(); codec_iter!=fAudioCodecs.end(); ++codec_iter)
@@ -227,9 +228,8 @@ ffguiwin::ffguiwin(BRect r, const char *name, window_type type, ulong mode)
 	}
 	outputaudioformatpopup->ItemAt(0)->SetMarked(true);
 	outputaudioformat = new BMenuField(B_TRANSLATE("Audio codec:"), outputaudioformatpopup);
-	menuWidth = outputaudioformat->PreferredSize();
-	menuWidth.height=B_SIZE_UNSET;
-	outputaudioformat->SetExplicitMinSize(menuWidth);
+	outputaudioformatpopup->GetPreferredSize(&popup_width, nullptr);
+	outputaudioformat->CreateMenuBarLayoutItem()->SetExplicitMinSize(BSize(popup_width, B_SIZE_UNSET));
 
 	enablevideo = new BCheckBox("", B_TRANSLATE("Enable video encoding"), new BMessage(M_ENABLEVIDEO));
 	enablevideo->SetValue(B_CONTROL_ON);

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -101,7 +101,7 @@ void ffguiwin::BuildLine() // ask all the views what they hold, reset the comman
 	commandline << " -f " << fileformat_option; // grab and set the file format
 
 	// is video enabled, add options
-	if (enablevideo->Value() == B_CONTROL_ON)
+	if ((enablevideo->Value() == B_CONTROL_ON) and (enablevideo->IsEnabled()))
 	{
 		option_index = outputvideoformatpopup->FindMarkedIndex();
 		commandline << " -vcodec " << fVideoCodecs[option_index].Option;

--- a/source/ffgui-window.cpp
+++ b/source/ffgui-window.cpp
@@ -65,11 +65,13 @@ static const char* kOutputIsSource = B_TRANSLATE_MARK(
 	"Cannot overwrite the source file. Please choose another output file name.");
 
 
-ContainerOption::ContainerOption(const BString& option, const BString& extension, const BString& description)
+ContainerOption::ContainerOption(	const BString& option, const BString& extension,
+									const BString& description, format_capability capability)
 	:
 	Option(option),
 	Extension(extension),
-	Description(description)
+	Description(description),
+	Capability(capability)
 {
 
 }
@@ -650,6 +652,12 @@ void ffguiwin::MessageReceived(BMessage *message)
 				is_ready_to_encode();
 				set_playbuttons_state();
 			}
+
+			int32 option_index = outputfileformatpopup->FindMarkedIndex();
+			if (fContainerFormats[option_index].Capability == CAP_AUDIO_ONLY)
+				enablevideo->SetEnabled(false);
+			else
+				enablevideo->SetEnabled(true);
 
 			BuildLine();
 			break;
@@ -1459,12 +1467,16 @@ ffguiwin::populate_codec_options()
 {
 
 	//	container formats
-	fContainerFormats.push_back(ContainerOption("avi","avi","AVI (Audio Video Interleaved)"));
-	fContainerFormats.push_back(ContainerOption("matroska","mkv","Matroska"));
-	fContainerFormats.push_back(ContainerOption("mp4","mp4","MPEG-4 Part 14"));
-	fContainerFormats.push_back(ContainerOption("mpeg","mpg","MPEG-1 Systems/MPEG Program Stream"));
-	fContainerFormats.push_back(ContainerOption("ogg","ogg","Ogg"));
-	fContainerFormats.push_back(ContainerOption("webm","webm","WebM"));
+	fContainerFormats.push_back(ContainerOption("avi","avi","AVI (Audio Video Interleaved)",
+												CAP_AUDIO_VIDEO));
+	fContainerFormats.push_back(ContainerOption("matroska","mkv","Matroska", CAP_AUDIO_VIDEO));
+	fContainerFormats.push_back(ContainerOption("mp4","mp4","MPEG-4 Part 14", CAP_AUDIO_VIDEO));
+	fContainerFormats.push_back(ContainerOption("mpeg","mpg","MPEG-1 Systems/MPEG Program Stream",
+												CAP_AUDIO_VIDEO));
+	fContainerFormats.push_back(ContainerOption("ogg","ogg","Ogg", CAP_AUDIO_VIDEO));
+	fContainerFormats.push_back(ContainerOption("webm","webm","WebM", CAP_AUDIO_VIDEO));
+	fContainerFormats.push_back(ContainerOption("flac","flac","FLAC", CAP_AUDIO_ONLY));
+	fContainerFormats.push_back(ContainerOption("mp3","mp3","MPEG audio layer 3", CAP_AUDIO_ONLY));
 
 	// video codecs
 	fVideoCodecs.push_back(CodecOption("copy","1:1 copy"));

--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -39,12 +39,20 @@ class ffguispinner;
 class ffguidecspinner;
 
 
+enum format_capability {
+	CAP_AUDIO_VIDEO,
+	CAP_AUDIO_ONLY
+};
+
+
 class ContainerOption {
 public:
-	ContainerOption(const BString& option, const BString& extension, const BString& description);
+	ContainerOption(const BString& option, const BString& extension,
+					const BString& description, format_capability capability);
 	BString Option;
 	BString Extension;
 	BString Description;
+	format_capability Capability;
 };
 
 

--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -16,7 +16,6 @@
 #include <Invoker.h>
 #include <Window.h>
 #include <vector>
-#include <utility>
 
 
 class BView;
@@ -38,6 +37,23 @@ class BStringView;
 class CommandLauncher;
 class ffguispinner;
 class ffguidecspinner;
+
+
+class ContainerOption {
+public:
+	ContainerOption(const BString& option, const BString& extension, const BString& description);
+	BString Option;
+	BString Extension;
+	BString Description;
+};
+
+
+class CodecOption {
+public:
+	CodecOption(const BString& option, const BString& description);
+	BString Option;
+	BString Description;
+};
 
 
 class ffguiwin : public BWindow
@@ -170,9 +186,9 @@ class ffguiwin : public BWindow
 			BInvoker fAlertInvoker;
 
 			// menu options for container format, video and audio codecs
-			std::vector<std::pair<BString, BString>> fContainerFormats;
-			std::vector<std::pair<BString, BString>> fVideoCodecs;
-			std::vector<std::pair<BString, BString>> fAudioCodecs;
+			std::vector<ContainerOption> fContainerFormats;
+			std::vector<CodecOption> fVideoCodecs;
+			std::vector<CodecOption> fAudioCodecs;
 
 
 			CommandLauncher *fCommandLauncher;

--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -15,6 +15,8 @@
 
 #include <Invoker.h>
 #include <Window.h>
+#include <vector>
+#include <utility>
 
 
 class BView;
@@ -66,7 +68,7 @@ class ffguiwin : public BWindow
 			void toggle_video();
 			void toggle_cropping();
 			void toggle_audio();
-
+			void populate_codec_options();
 
 			//main view
 			BView *topview;
@@ -166,6 +168,12 @@ class ffguiwin : public BWindow
 			// alerts
 			BAlert* fStopAlert;
 			BInvoker fAlertInvoker;
+
+			// menu options for container format, video and audio codecs
+			std::vector<std::pair<BString, BString>> fContainerFormats;
+			std::vector<std::pair<BString, BString>> fVideoCodecs;
+			std::vector<std::pair<BString, BString>> fAudioCodecs;
+
 
 			CommandLauncher *fCommandLauncher;
 };


### PR DESCRIPTION
New classes ContainerOption and CodecOption are introduced. Format and codec options are kept in std::vector containers of these classes. 
This gives us the possibility to use descriptive names in the popup menus instead of the ffmpeg option strings. 
The available options are still managed manually, because fetching them from ffmpeg would give us too many of them. 

Problem: currently messes up the layout when codec options are switched away from "1:1" copy. 
@humdingerb : Could you please take a look at this and maybe make some suggestions ;-)