### PR TITLE
Use short labels for format and audio/video codecs

### DIFF
--- a/source/ffgui-window.h
+++ b/source/ffgui-window.h
@@ -57,8 +57,10 @@ public:
 
 class CodecOption {
 public:
-					CodecOption(const BString& option, const BString& description);
+					CodecOption(const BString& option, const BString& shortlabel,
+						const BString& description);
 	BString 		Option;
+	BString Shortlabel;
 	BString 		Description;
 };
 


### PR DESCRIPTION
To avoid quite wide pop-up menus, show a short label for the selected item. Only show the long descriptions of the items additionally when opening the menus.

Fixes #93