### PR TITLE
Jobs: Start a single job on double-click

### DIFF
--- a/source/JobList.cpp
+++ b/source/JobList.cpp
@@ -31,6 +31,7 @@ JobRow::JobRow(int32 jobnumber, const char* filename, const char* duration,
 	const char* commandline, int32 statusID)
 	:
 	BRow(),
+	fJobNumber(jobnumber),
 	fFilename(filename),
 	fDuration(duration),
 	fCommandLine(commandline),

--- a/source/JobList.h
+++ b/source/JobList.h
@@ -22,7 +22,7 @@ enum {
 	WAITING = 0,
 	RUNNING,
 	FINISHED,
-	ERROR
+	ERROR,
 };
 
 class JobList : public BColumnListView {
@@ -36,6 +36,7 @@ public:
 					JobRow(int32 jobnumber, const char* jobname, const char* duration,
 						const char* commandline, int32 statusID);
 
+	int32			GetJobNumber() { return fJobNumber; };
 	const char*		GetFilename() { return fFilename.String(); };
 	const char*		GetJobName() { return fJobName.String(); };
 	const char*		GetDuration() { return fDuration.String(); };
@@ -55,6 +56,7 @@ private:
 	BString			fCommandLine;
 	BString			fStatus;
 	BString			fLog;
+	int32			fJobNumber;
 	int32			fDurationSecs;
 	int32			fStatusID;
 };

--- a/source/JobWindow.h
+++ b/source/JobWindow.h
@@ -57,6 +57,7 @@ private:
 	int32			fJobNumber;
 
 	bool			fJobRunning;
+	int32			fSingleJob;
 
 	BButton*		fStartAbortButton;
 	BButton*		fRemoveButton;

--- a/source/Messages.h
+++ b/source/Messages.h
@@ -93,6 +93,7 @@ enum {
 	 M_JOB_LOG,
 	 M_JOB_REMOVE,
 	 M_JOB_COUNT,
+	 M_SINGLE_JOB,
 	 M_CLEAR_LIST,
 	 M_LIST_UP,
 	 M_LIST_DOWN,


### PR DESCRIPTION
When double-clicking a job we already show the log on ERROR, and play the output file on FINISHED.

Now we start encoding the currently selected single job, if the job status is WAITING. When finished, we _don't_ continue with the rest of the jobs in the list.

fSingleJob tracks the status:
WAITING = no single job in progress
RUNNING = single job in progress
FINISHED = finished encoding single job

The window title changes: it just shows the running job number and progress percentage.
The Start/Abort button shows the singular: "Abort job"