### PR TITLE
Spinners: Allow not doing an Invoke() on SetValue()

### DIFF
--- a/source/Spinner.cpp
+++ b/source/Spinner.cpp
@@ -12,9 +12,29 @@
 
 Spinner::Spinner(const char* name, const char* label, BMessage* message)
 	:
-	BSpinner(name, label, message)
+	BSpinner(name, label, message),
+	fInvoke(true)
 {
 	fStep = 1;
+}
+
+
+status_t
+Spinner::Invoke(BMessage* message)
+{
+	if (fInvoke == false) {
+		fInvoke = true;
+		return B_OK;
+	}
+	return (BSpinner::Invoke(message));
+}
+
+
+void
+Spinner::SetWithoutInvoke(int32 value)
+{
+	fInvoke = false;
+	BSpinner::SetValue(value);
 }
 
 
@@ -42,9 +62,37 @@ Spinner::SetStep(int32 step)
 // Spinner for floating point
 DecSpinner::DecSpinner(const char* name, const char* label, BMessage* message)
 	:
-	BDecimalSpinner(name, label, message)
+	BDecimalSpinner(name, label, message),
+	fInvoke(true)
 {
 	SetPrecision(0);
+}
+
+
+status_t
+DecSpinner::Invoke(BMessage* message)
+{
+	if (fInvoke == false) {
+		fInvoke = true;
+		return B_OK;
+	}
+	return (BDecimalSpinner::Invoke(message));
+}
+
+
+void
+DecSpinner::SetWithoutInvoke(double value)
+{
+	fInvoke = false;
+	BDecimalSpinner::SetValue(value);
+}
+
+
+void
+DecSpinner::SetWithoutInvoke(int32 value)
+{
+	fInvoke = false;
+	BDecimalSpinner::SetValue(value);
 }
 
 

--- a/source/Spinner.h
+++ b/source/Spinner.h
@@ -16,23 +16,36 @@
 
 class Spinner : public BSpinner {
 public:
-			Spinner(const char* name, const char* label, BMessage* message);
+						Spinner(const char* name, const char* label, BMessage* message);
 
+	// Allow not doing an Invoke() on SetValue() until Haiku's BSpinner class is fixed
+	virtual status_t	Invoke(BMessage* message = NULL);
+
+	void 	SetWithoutInvoke(int32 value);
 	void 	Increment();
 	void 	Decrement();
 	void 	SetStep(int32 step);
 
 private:
+	bool	fInvoke;
 	int32 	fStep;
 };
 
 
 class DecSpinner : public BDecimalSpinner {
 public:
-			DecSpinner(const char* name, const char* label, BMessage* message);
+						DecSpinner(const char* name, const char* label, BMessage* message);
 
+	// Allow not doing an Invoke() on SetValue() until Haiku's BSpinner class is fixed
+	virtual status_t	Invoke(BMessage* message = NULL);
+
+	void 	SetWithoutInvoke(int32 value);
+	void 	SetWithoutInvoke(double value);
 	void 	Increment();
 	void 	Decrement();
+
+private:
+	bool	fInvoke;
 };
 
 #endif // SPINNER_H


### PR DESCRIPTION
We want to be able to do a SetValue() without there being an Invoke() triggered, which sends a message as if the user used the spinner. No other BControl derived class does this. This is a stop-gap until Haiku's BSpinner class is fixed, see [1].

Now, we have an optional bool parameter:
SetValue(in32 value, bool invoke = true);
To avoid triggering Invoke(), set the bool to false.

[1] https://dev.haiku-os.org/ticket/18305