### PR TITLE
Add "Help" and "FFmpeg documentation" in new "ffmpegGUI" menu

### DIFF
--- a/source/MainWindow.h
+++ b/source/MainWindow.h
@@ -90,6 +90,8 @@ private:
 
 	void 			_ReadyToEncode();
 	void 			_PlayVideo(const char* filepath);
+	void 			_OpenHelp();
+	void 			_OpenURL(BString url);
 
 	void 			_SetPlaybuttonsState();
 	void 			_ToggleVideo();

--- a/source/Messages.h
+++ b/source/Messages.h
@@ -87,6 +87,8 @@ enum {
  	 M_ADD_JOB,
 	 M_JOB_MANAGER,
 	 M_DEFAULTS,
+	 M_HELP,
+	 M_WEBSITE,
 };
 // Job window
 enum {


### PR DESCRIPTION
* Added "ffmpegGUI" menu.
* Move non-file related items "About" and "Quit" to it.
* Add item "Help" to open ReadMe.html in $docsDir/packages/ffmpegGUI/
* Add item "FFmpeg documentation" that opens https://ffmpeg.org/ffmpeg.html The URL can be changed at translation to point to a localized ressorce.