### PR TITLE
Set minimum value for audio channels to 1

### DIFF
--- a/source/MainWindow.cpp
+++ b/source/MainWindow.cpp
@@ -1224,6 +1224,7 @@ MainWindow::_BuildMainOptions()
 	fSampleratePopup->ItemAt(1)->SetMarked(true);
 	fSamplerate = new BMenuField(B_TRANSLATE("Sampling rate (Hz):"), fSampleratePopup);
 	fChannelCount = new Spinner("", B_TRANSLATE("Audio channels:"), new BMessage(M_CHANNELS));
+	fChannelCount->SetMinValue(1);
 
 	// _Build Audio Options layout
 	BBox* audiobox = new BBox("");


### PR DESCRIPTION
The spinner for the number of audio channel previously had no lower limit. Since even my quite overactive imagination can't imagine a negative number of audio channels, and 0 makes no sense as well (if no audio is wanted, disable audio encoding), I've set the minimum value to 1. 